### PR TITLE
Update method for getting Signal uuid, password

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Intial setup
     - Goto Menu 
 		- Toggle Developers tools 
 		- On there open Console 
-		- Store somehwere output of window.reduxStore.getState().items.uuid_id 
-		- Also store outut of window.reduxStore.getState().items.password
+		- Store somehwere output of `window.reduxStore.getState().items.uuid_id`
+		- Also store outut of `window.reduxStore.getState().items.password`
 
 #### Don't share both of these with anyone else
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Intial setup
     - Goto Menu 
 		- Toggle Developers tools 
 		- On there open Console 
-		- Store somehwere output of `window.reduxStore.getState().items.uuid_id`
-		- Also store outut of `window.reduxStore.getState().items.password`
+		- Store somehwere output of `window.SignalDebug.getReduxState().items.uuid_id`
+		- Also store output of `window.SignalDebug.getReduxState().items.password`
 
 #### Don't share both of these with anyone else
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For Rust program , you would need
 ---
 Intial setup 
 1. Get Telegram Bot token ready
-2. Now open Signal Desktop in the commandline with `signal-desktop --enable-dev-tools`
+2. Install and launch Signal Desktop [BETA VERSION](https://support.signal.org/hc/en-us/articles/360007318471-Signal-Beta)
     - Goto Menu 
 		- Toggle Developers tools 
 		- On there open Console 


### PR DESCRIPTION
After recent update, getting Signal uuid and password with the method in README is broken. See another issue I have created: https://github.com/signalstickers/signalstickers-client/issues/15

This PR will update the instructions for getting uuid and password